### PR TITLE
Deactivates user instead of deleting so requests stick around

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       # Log in and redirect to the user profile page
       if user.email_confirmed
-        if user_approved(user)
+        if user.status_approved?
           log_in user
           redirect_back_or user
         else
@@ -32,9 +32,5 @@ class SessionsController < ApplicationController
   def destroy
     log_out
     redirect_to root_url
-  end
-
-  def user_approved(user)
-    user.status == 'approved'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -74,8 +74,9 @@ class UsersController < ApplicationController
 
   # DELETE /users/1
   def destroy
-    User.find(params[:id]).destroy
-    flash[:success] = "User account deleted!"
+    user = User.find(params[:id])
+    user.update!(status: 0)
+    flash[:success] = "User account deactivated!"
     redirect_to users_url
   end
 
@@ -86,7 +87,7 @@ class UsersController < ApplicationController
       flash[:success] = "Welcome to the ECE Inventory System Your email has been confirmed. An Admin will verify your account shortly."
       redirect_to root_url
     else
-      flash[:error] = "Sorry. User does not exist"
+      flash[:danger] = "Sorry. User does not exist"
       redirect_to root_url
     end
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -45,7 +45,7 @@ module SessionsHelper
   def store_location
     session[:forwarding_url] = request.original_url if request.get?
   end
-  
+
   # Checks that the current user is an administrator
   def check_admin_user
     redirect_to(root_url) unless current_user && current_user.privilege_admin?
@@ -75,7 +75,7 @@ module SessionsHelper
 
   # Confirms status is approved
   def check_approved_user
-    unless logged_in?
+    unless current_user.status_approved?
       store_location
       flash[:danger] = "Your account has not been approved."
       redirect_to login_url and return
@@ -83,7 +83,7 @@ module SessionsHelper
   end
 
   def activate_user(user)
-    user.status = "approved"
+    user.status = 'approved'
     user.save!(:validate => false)
   end
 end

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -12,17 +12,13 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     get users_path
     assert_template 'users/index'
     assert_select 'div.pagination'
-    first_page = User.paginate(page: 1, per_page: 10)
+    first_page = User.where(status: 1).paginate(page: 1, per_page: 10)
     
     first_page.each do |user|
       assert_select 'a[href=?]', user_path(user), text: user.username
       unless user.privilege_admin?
         assert_select 'a[href=?]', user_path(user), text: 'delete'
       end
-    end
-
-    assert_difference 'User.count', -1 do
-      delete user_path(@non_admin)
     end
   end
 


### PR DESCRIPTION
Instead of admin deleting a user, it just changes the status back to waiting and the user goes back into "Account Requests" section for admin. 

small issue is that if the user is currently logged on when the admin deactivates them, it doesn't log them out but it just keeps giving the message "you are already logged in" for some reason. Something to do with the session id, but I couldn't figure out how to make a log_out_user(user) method that worked @boyangles 
