### PR TITLE
Fix deprecated tests (but not really)

### DIFF
--- a/spec/controllers/concerns/authenticable_spec.rb
+++ b/spec/controllers/concerns/authenticable_spec.rb
@@ -12,7 +12,7 @@ describe Authenticable do
     before do
       @user = FactoryGirl.create :user
       request.headers['Authorization'] = @user.auth_token
-      authentication.stub(:request).and_return(request)
+      allow(subject).to receive(:request).and_return(request)
     end
 
     it 'returns the user from the authorization header' do
@@ -23,36 +23,36 @@ describe Authenticable do
   describe "#authenticate_with_token" do
     before do
       @user = FactoryGirl.create :user
-      authentication.stub(:current_user_by_auth).and_return(nil)
-      response.stub(:response_code).and_return(401)
-      response.stub(:body).and_return({'errors' => 'Not authenticated'}.to_json)
-      authentication.stub(:response).and_return(response)
+      allow(subject).to receive(:current_user_by_auth).and_return(nil)
+      allow(response).to receive(:response_code).and_return(401)
+      allow(response).to receive(:body).and_return({'errors' => 'Not authenticated'}.to_json)
+      allow(subject).to receive(:response).and_return(response)
     end
 
     it "render a json error message" do
       expect(json_response[:errors]).to eql 'Not authenticated'
     end
 
-    it { should respond_with 401 }
+    it { expect(subject).to  respond_with 401 }
   end
 
   describe "#user_signed_in?" do
     context "when there is a user on 'session'" do
       before do
         @user = FactoryGirl.create :user
-        authentication.stub(:current_user_by_auth).and_return(@user)
+        allow(subject).to receive(:current_user_by_auth).and_return(@user)
       end
 
-      it { should be_user_signed_in }
+      it { expect(subject).to  be_user_signed_in }
     end
 
     context "when there is no user on 'session'" do
       before do
         @user = FactoryGirl.create :user
-        authentication.stub(:current_user_by_auth).and_return(nil)
+        allow(subject).to receive(:current_user_by_auth).and_return(nil)
       end
 
-      it { should_not be_user_signed_in }
+      it { expect(subject).not_to  be_user_signed_in }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,23 +3,23 @@ require 'rails_helper'
 describe User do
   before { @user = FactoryGirl.build(:user) }
 
-  subject{ @user }
+  subject { @user }
 
-  it { should respond_to(:email) }
-  it { should respond_to(:password) }
-  it { should respond_to(:password_confirmation) }
-  it { should respond_to(:auth_token) }
+  it { expect(subject).to respond_to(:email) }
+  it { expect(subject).to respond_to(:password) }
+  it { expect(subject).to respond_to(:password_confirmation) }
+  it { expect(subject).to respond_to(:auth_token) }
 
   # TODO: Change when validation of email is finalized
-  xit { should validate_presence_of(:email) }
-  it { should validate_uniqueness_of(:email).case_insensitive }
-  it { should validate_confirmation_of(:password) }
-  it { should allow_value('example@duke.edu').for(:email) }
-  it { should validate_uniqueness_of(:auth_token) }
+  xit { expect(subject).to validate_presence_of(:email) }
+  it { expect(subject).to  validate_uniqueness_of(:email).case_insensitive }
+  it { expect(subject).to  validate_confirmation_of(:password) }
+  it { expect(subject).to  allow_value('example@duke.edu').for(:email) }
+  it { expect(subject).to  validate_uniqueness_of(:auth_token) }
 
   describe "#generate_authentication_token!" do
     it "generates a unique token" do
-      Devise.stub(:friendly_token).and_return("auniquetoken123")
+      allow(Devise).to receive(:friendly_token).and_return("auniquetoken123")
       @user.generate_authentication_token!
       expect(@user.auth_token).to eql "auniquetoken123"
     end
@@ -31,7 +31,7 @@ describe User do
     end
   end
 
-  it { should be_valid }
+  it { expect(subject).to be_valid }
 end
 
 RSpec.describe "sign in tests", :type => :feature do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,7 @@ RSpec.configure do |config|
   # Including to test requests
   config.include URLRequest::JsonHelpers, :type => :controller
   config.include URLRequest::HeadersHelpers, :type => :controller
-  config.include Devise::TestHelpers, :type => :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
 
   config.before(:each, type: :controller) do
     include_default_accept_headers


### PR DESCRIPTION
I was hoping to get rid of all deprecation warnings, but couldn't find where these warnings were occurring, since the warnings do not show the correct location: -> 
https://github.com/rails/rails/issues/27343

Deprecated style:
get :show, { id: 1 }, nil, { notice: "This is a flash message" }

New keyword style:
get :show, params: { id: 1 }, flash: { notice: "This is a flash message" },
  session: nil # Can safely be omitted.
 (called from block (3 levels) in <top (required)> at /Users/jf/Desktop/Spring 2017/ECE458/ece-inventory-app/spec/controllers/api/v1/logs_controller_spec.rb:96)

